### PR TITLE
Install the bash kernel in sys prefix

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -2,4 +2,4 @@ jupyter labextension install \
   jupyterlab-topbar-extension \
   jupyterlab-system-monitor
 
-python -m bash_kernel.install
+python -m bash_kernel.install --sys-prefix


### PR DESCRIPTION
So the `bash` kernel ends up next to the `python` in the prefix, instead of being in the user home directory:

### Before

```
jovyan@jupyter-plasmabio-2dtemplate-2dbash-2dgnhwbcr7:~$ jupyter kernelspec list
Available kernels:
  bash       /home/jovyan/.local/share/jupyter/kernels/bash
  python3    /srv/conda/envs/notebook/share/jupyter/kernels/python3
```

### After

```
jovyan@jupyter-plasmabio-2dtemplate-2dbash-2doegzwtav:~$ jupyter kernelspec list
Available kernels:
  bash       /srv/conda/envs/notebook/share/jupyter/kernels/bash
  python3    /srv/conda/envs/notebook/share/jupyter/kernels/python3
```